### PR TITLE
fix deprecation warning about ${name} in maven 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                 <generatedSourcesDirectory>${project.basedir}/src/main/generated</generatedSourcesDirectory>
                 <compilerArgs>
                   <arg>-AoutputDirectory=${project.basedir}/src/main</arg>
-                  <arg>-Adocgen.output=${asciidoc.dir}/${name}</arg>
+                  <arg>-Adocgen.output=${asciidoc.dir}/${project.name}</arg>
                 </compilerArgs>
               </configuration>
             </execution>


### PR DESCRIPTION
one of the asciidoc rules in the ext-parent used ${name} which is deprecated in the current maven, I have changed the expression to ${project.name}
