### PR TITLE
Fix Windows relative paths

### DIFF
--- a/resources/src/main/resources/assemblies/docs.xml
+++ b/resources/src/main/resources/assemblies/docs.xml
@@ -9,11 +9,11 @@
   <fileSets>
     <fileSet>
       <directory>${asciidoc.dir}</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.build.directory}/docs/${project.artifactId}</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
       <includes>
         <include>groovy/groovydoc/**</include>
         <include>js/jsdoc/**</include>

--- a/resources/src/main/resources/assemblies/sources.xml
+++ b/resources/src/main/resources/assemblies/sources.xml
@@ -13,7 +13,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/src/main/resources</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/src/main/generated</directory>

--- a/resources/src/main/resources/assemblies/sources.xml
+++ b/resources/src/main/resources/assemblies/sources.xml
@@ -9,7 +9,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}/src/main/java</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/src/main/resources</directory>
@@ -17,11 +17,11 @@
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/src/main/generated</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/src/main/groovy</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
Fix an issue under Windows when I tried to use vertx-ext-parent as parent project : 

``` sh
--- maven-assembly-plugin:2.6:single (package-sources) @ vertx-async ---
Downloading: https://repo.maven.apache.org/maven2/io/vertx/vertx-ext-resources/20/vertx-ext-resources-20.jar

Downloaded: https://repo.maven.apache.org/maven2/io/vertx/vertx-ext-resources/20/vertx-ext-resources-20.jar (3 KB at 3.1 KB/sec)
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
Building jar: C:\Users\Guillaume\Documents\NetBeansProjects\vertx-async\target\vertx-async-1.0.1-SNAPSHOT-sources.jar

--- maven-assembly-plugin:2.6:single (package-docs) @ vertx-async ---
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
```
